### PR TITLE
feat: Download community posts as 1:1 images for social media sharing

### DIFF
--- a/app/components/community/community-overview.tsx
+++ b/app/components/community/community-overview.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Users, PenTool, BookOpen, Heart, MessageCircle, Filter, Search } from 'lucide-react'
+import { DownloadPostButton } from '@/components/community/download-post-button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import Link from 'next/link'
@@ -257,6 +258,7 @@ export function CommunityOverview() {
                           <MessageCircle className="w-4 h-4 mr-1" />
                           Comment
                         </Button>
+                        <DownloadPostButton post={post} />
                       </div>
                       
                       {post.exercise && (

--- a/app/components/community/download-post-button.tsx
+++ b/app/components/community/download-post-button.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Download, Loader2, Check } from 'lucide-react'
+import { downloadPostAsImage, PostImageData } from '@/lib/generate-post-image'
+import { toast } from 'sonner'
+
+interface DownloadPostButtonProps {
+  post: {
+    id: string
+    title: string
+    content: string
+    createdAt: string
+    user: {
+      firstName?: string
+      lastName?: string
+      name?: string
+    }
+    exercise?: {
+      title: string
+      topic: {
+        title: string
+        slug: string
+      }
+    }
+  }
+}
+
+export function DownloadPostButton({ post }: DownloadPostButtonProps) {
+  const [isDownloading, setIsDownloading] = useState(false)
+  const [downloaded, setDownloaded] = useState(false)
+
+  const handleDownload = async () => {
+    setIsDownloading(true)
+    setDownloaded(false)
+
+    try {
+      const authorName = post.user?.firstName && post.user?.lastName
+        ? `${post.user.firstName} ${post.user.lastName}`
+        : post.user?.name || 'Anonymous Writer'
+
+      const date = new Date(post.createdAt).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+      })
+
+      const imageData: PostImageData = {
+        title: post.title || 'Exercise Response',
+        content: post.content,
+        authorName,
+        exerciseTitle: post.exercise?.title,
+        topicTitle: post.exercise?.topic.title,
+        date
+      }
+
+      // Generate filename from title
+      const sanitizedTitle = (post.title || 'post')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .slice(0, 30)
+      const filename = `writers-corner-${sanitizedTitle}-${post.id.slice(0, 8)}.png`
+
+      await downloadPostAsImage(imageData, filename)
+      
+      setDownloaded(true)
+      toast.success('Image downloaded successfully!', {
+        description: 'Your post image is ready to share on social media.'
+      })
+
+      // Reset downloaded state after 2 seconds
+      setTimeout(() => setDownloaded(false), 2000)
+    } catch (error) {
+      console.error('Error downloading post:', error)
+      toast.error('Failed to download image', {
+        description: 'Please try again later.'
+      })
+    } finally {
+      setIsDownloading(false)
+    }
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={handleDownload}
+      disabled={isDownloading}
+      className="text-forest hover:text-rust transition-colors"
+      title="Download as image for social media"
+    >
+      {isDownloading ? (
+        <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+      ) : downloaded ? (
+        <Check className="w-4 h-4 mr-1 text-forest" />
+      ) : (
+        <Download className="w-4 h-4 mr-1" />
+      )}
+      {isDownloading ? 'Creating...' : downloaded ? 'Downloaded' : 'Share'}
+    </Button>
+  )
+}

--- a/app/lib/generate-post-image.ts
+++ b/app/lib/generate-post-image.ts
@@ -1,0 +1,229 @@
+/**
+ * Utility to generate 1:1 square images from community posts for social media sharing
+ * Includes "Writers Corner" watermark styled consistently with the vintage UI theme
+ */
+
+export interface PostImageData {
+  title: string
+  content: string
+  authorName: string
+  exerciseTitle?: string
+  topicTitle?: string
+  date: string
+}
+
+// CSS color variables from the app
+const COLORS = {
+  parchment: 'hsl(43, 74%, 94%)',  // Background
+  ink: 'hsl(25, 25%, 15%)',         // Primary text
+  sepia: 'hsl(37, 45%, 85%)',       // Secondary background
+  rust: 'hsl(16, 85%, 55%)',        // Accent
+  forest: 'hsl(145, 25%, 35%)',     // Secondary text
+  gold: 'hsl(45, 85%, 65%)',        // Highlight
+}
+
+/**
+ * Wraps text to fit within a specified width
+ */
+function wrapText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number
+): string[] {
+  const words = text.split(' ')
+  const lines: string[] = []
+  let currentLine = ''
+
+  for (const word of words) {
+    const testLine = currentLine ? `${currentLine} ${word}` : word
+    const metrics = ctx.measureText(testLine)
+    
+    if (metrics.width > maxWidth && currentLine) {
+      lines.push(currentLine)
+      currentLine = word
+    } else {
+      currentLine = testLine
+    }
+  }
+  
+  if (currentLine) {
+    lines.push(currentLine)
+  }
+  
+  return lines
+}
+
+/**
+ * Generates a 1:1 square image (1080x1080) from post data
+ * Returns a data URL of the generated image
+ */
+export function generatePostImage(data: PostImageData): Promise<string> {
+  return new Promise((resolve, reject) => {
+    try {
+      const size = 1080 // Instagram recommended size
+      const padding = 80
+      const contentWidth = size - padding * 2
+
+      const canvas = document.createElement('canvas')
+      canvas.width = size
+      canvas.height = size
+      const ctx = canvas.getContext('2d')
+
+      if (!ctx) {
+        reject(new Error('Could not get canvas context'))
+        return
+      }
+
+      // Background - parchment color
+      ctx.fillStyle = COLORS.parchment
+      ctx.fillRect(0, 0, size, size)
+
+      // Add subtle paper texture effect
+      ctx.fillStyle = 'rgba(120, 119, 98, 0.03)'
+      for (let i = 0; i < 50; i++) {
+        const x = Math.random() * size
+        const y = Math.random() * size
+        const radius = Math.random() * 100 + 50
+        ctx.beginPath()
+        ctx.arc(x, y, radius, 0, Math.PI * 2)
+        ctx.fill()
+      }
+
+      // Border - vintage card style
+      ctx.strokeStyle = COLORS.ink
+      ctx.lineWidth = 4
+      ctx.strokeRect(padding / 2, padding / 2, size - padding, size - padding)
+
+      // Inner decorative border
+      ctx.strokeStyle = COLORS.sepia
+      ctx.lineWidth = 2
+      ctx.strokeRect(padding / 2 + 12, padding / 2 + 12, size - padding - 24, size - padding - 24)
+
+      let yPosition = padding + 20
+
+      // Title
+      ctx.fillStyle = COLORS.ink
+      ctx.font = 'bold 48px "Courier Prime", Courier, monospace'
+      ctx.textAlign = 'left'
+      
+      const titleLines = wrapText(ctx, data.title || 'Exercise Response', contentWidth)
+      for (const line of titleLines.slice(0, 2)) {
+        ctx.fillText(line, padding, yPosition + 48)
+        yPosition += 56
+      }
+      yPosition += 20
+
+      // Author badge
+      ctx.fillStyle = COLORS.rust
+      ctx.font = '600 28px "Courier Prime", Courier, monospace'
+      ctx.fillText(`✦ ${data.authorName}`, padding, yPosition)
+      yPosition += 40
+
+      // Topic/Exercise info
+      if (data.topicTitle || data.exerciseTitle) {
+        ctx.fillStyle = COLORS.forest
+        ctx.font = 'italic 24px "Crimson Text", Georgia, serif'
+        const exerciseInfo = data.topicTitle 
+          ? `${data.topicTitle}${data.exerciseTitle ? ` — ${data.exerciseTitle}` : ''}`
+          : data.exerciseTitle
+        if (exerciseInfo) {
+          const infoLines = wrapText(ctx, exerciseInfo, contentWidth)
+          ctx.fillText(infoLines[0], padding, yPosition)
+          yPosition += 36
+        }
+      }
+
+      // Divider line
+      yPosition += 10
+      ctx.strokeStyle = COLORS.gold
+      ctx.lineWidth = 3
+      ctx.beginPath()
+      ctx.moveTo(padding, yPosition)
+      ctx.lineTo(padding + 200, yPosition)
+      ctx.stroke()
+      yPosition += 40
+
+      // Content
+      ctx.fillStyle = COLORS.ink
+      ctx.font = '32px "Crimson Text", Georgia, serif'
+      
+      // Calculate available space for content (leave room for watermark)
+      const maxContentY = size - 180 // Reserve space for watermark
+      const lineHeight = 44
+      const contentLines = wrapText(ctx, data.content, contentWidth)
+      
+      let linesDrawn = 0
+      for (const line of contentLines) {
+        if (yPosition + lineHeight > maxContentY) {
+          // Add ellipsis if content is truncated
+          if (linesDrawn > 0) {
+            ctx.fillText('...', padding, yPosition)
+          }
+          break
+        }
+        ctx.fillText(line, padding, yPosition + 32)
+        yPosition += lineHeight
+        linesDrawn++
+      }
+
+      // Date (bottom left area)
+      ctx.fillStyle = COLORS.forest
+      ctx.font = '22px "Crimson Text", Georgia, serif'
+      ctx.fillText(data.date, padding, size - 100)
+
+      // Watermark - "Writers Corner" with vintage styling
+      const watermarkY = size - padding / 2 - 20
+      
+      // Decorative line above watermark
+      ctx.strokeStyle = COLORS.ink
+      ctx.lineWidth = 2
+      ctx.beginPath()
+      ctx.moveTo(size - 380, watermarkY - 30)
+      ctx.lineTo(size - padding, watermarkY - 30)
+      ctx.stroke()
+
+      // Writers Corner text
+      ctx.fillStyle = COLORS.ink
+      ctx.font = 'bold 32px "Courier Prime", Courier, monospace'
+      ctx.textAlign = 'right'
+      ctx.fillText('Writers Corner', size - padding, watermarkY)
+
+      // Small decorative quill/pen icon using text
+      ctx.font = '24px serif'
+      ctx.fillText('✎', size - 355, watermarkY)
+
+      // Small tagline
+      ctx.fillStyle = COLORS.forest
+      ctx.font = 'italic 18px "Crimson Text", Georgia, serif'
+      ctx.fillText('Share your story', size - padding, watermarkY + 24)
+
+      // Convert to data URL
+      const dataUrl = canvas.toDataURL('image/png', 1.0)
+      resolve(dataUrl)
+    } catch (error) {
+      reject(error)
+    }
+  })
+}
+
+/**
+ * Downloads the generated image
+ */
+export async function downloadPostAsImage(
+  data: PostImageData,
+  filename?: string
+): Promise<void> {
+  try {
+    const dataUrl = await generatePostImage(data)
+    
+    const link = document.createElement('a')
+    link.download = filename || `writers-corner-${Date.now()}.png`
+    link.href = dataUrl
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  } catch (error) {
+    console.error('Error downloading post image:', error)
+    throw error
+  }
+}


### PR DESCRIPTION
## Description
This PR adds a feature to download community posts as 1:1 square images (1080x1080) optimized for social media sharing.

## Features
- **Download button** added to each community post card
- **1:1 square format** (1080x1080px) - ideal for Instagram, Twitter, and other platforms
- **"Writers Corner" watermark** styled consistently with the vintage UI theme:
  - Courier Prime typewriter font
  - Parchment background with subtle paper texture
  - Ink/rust/forest/gold color scheme
  - Decorative borders matching the card-vintage style

## Components Added
- `lib/generate-post-image.ts` - Canvas-based image generation utility
- `components/community/download-post-button.tsx` - Download button component with loading states

## Changes
- Modified `community-overview.tsx` to include the download button alongside Like/Comment actions

## How It Works
1. User clicks the "Share" button on any community post
2. Canvas API generates a styled 1080x1080 PNG image
3. Image includes: title, author, topic/exercise info, content excerpt, date, and watermark
4. Image downloads automatically with a descriptive filename

## Preview
The generated image maintains the vintage aesthetic with:
- Parchment-colored background
- Typewriter and serif fonts
- Decorative borders
- "Writers Corner" branding with quill icon
