### PR TITLE
feat: Add save posts feature

### DIFF
--- a/app/app/api/community/posts/route.ts
+++ b/app/app/api/community/posts/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
       )
     }
 
-    // Fetch public exercise submissions
+    // Fetch public exercise submissions with saved status
     const submissions = await prisma.exerciseSubmission.findMany({
       where: {
         isPublic: true
@@ -40,6 +40,14 @@ export async function GET() {
               }
             }
           }
+        },
+        savedBy: {
+          where: {
+            userId: session.user.id
+          },
+          select: {
+            id: true
+          }
         }
       },
       orderBy: {
@@ -55,7 +63,9 @@ export async function GET() {
       content: submission.content,
       createdAt: submission.createdAt.toISOString(),
       user: submission.user,
-      exercise: submission.exercise
+      exercise: submission.exercise,
+      isSaved: submission.savedBy.length > 0,
+      savedPostId: submission.savedBy[0]?.id || null
     }))
 
     return NextResponse.json({ posts })

--- a/app/app/api/saved-posts/[id]/route.ts
+++ b/app/app/api/saved-posts/[id]/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import '@/lib/types'
+
+export const dynamic = 'force-dynamic'
+
+// DELETE /api/saved-posts/[id] - Unsave a post
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions)
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+
+    // Find the saved post and verify ownership
+    const savedPost = await prisma.savedPost.findUnique({
+      where: { id }
+    })
+
+    if (!savedPost) {
+      return NextResponse.json(
+        { error: 'Saved post not found' },
+        { status: 404 }
+      )
+    }
+
+    if (savedPost.userId !== session.user.id) {
+      return NextResponse.json(
+        { error: 'Unauthorized - you can only unsave your own saved posts' },
+        { status: 403 }
+      )
+    }
+
+    // Delete the saved post
+    await prisma.savedPost.delete({
+      where: { id }
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error unsaving post:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/app/api/saved-posts/route.ts
+++ b/app/app/api/saved-posts/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import '@/lib/types'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/saved-posts - Get all saved posts for the logged-in user
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions)
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const savedPosts = await prisma.savedPost.findMany({
+      where: {
+        userId: session.user.id
+      },
+      include: {
+        submission: {
+          include: {
+            user: {
+              select: {
+                firstName: true,
+                lastName: true,
+                name: true
+              }
+            },
+            exercise: {
+              include: {
+                topic: {
+                  select: {
+                    title: true,
+                    slug: true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      orderBy: {
+        savedAt: 'desc'
+      }
+    })
+
+    // Transform to match the expected format
+    const posts = savedPosts.map(savedPost => ({
+      id: savedPost.submission.id,
+      savedPostId: savedPost.id,
+      title: savedPost.submission.exercise.title,
+      content: savedPost.submission.content,
+      createdAt: savedPost.submission.createdAt.toISOString(),
+      savedAt: savedPost.savedAt.toISOString(),
+      user: savedPost.submission.user,
+      exercise: savedPost.submission.exercise
+    }))
+
+    return NextResponse.json({ posts })
+  } catch (error) {
+    console.error('Error fetching saved posts:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+// POST /api/saved-posts - Save a post
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions)
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const body = await request.json()
+    const { submissionId } = body
+
+    if (!submissionId) {
+      return NextResponse.json(
+        { error: 'Submission ID is required' },
+        { status: 400 }
+      )
+    }
+
+    // Check if the submission exists and is public
+    const submission = await prisma.exerciseSubmission.findUnique({
+      where: { id: submissionId }
+    })
+
+    if (!submission) {
+      return NextResponse.json(
+        { error: 'Submission not found' },
+        { status: 404 }
+      )
+    }
+
+    if (!submission.isPublic) {
+      return NextResponse.json(
+        { error: 'Cannot save a private submission' },
+        { status: 403 }
+      )
+    }
+
+    // Check if already saved
+    const existingSave = await prisma.savedPost.findUnique({
+      where: {
+        userId_submissionId: {
+          userId: session.user.id,
+          submissionId
+        }
+      }
+    })
+
+    if (existingSave) {
+      return NextResponse.json(
+        { error: 'Post already saved' },
+        { status: 409 }
+      )
+    }
+
+    // Create the saved post
+    const savedPost = await prisma.savedPost.create({
+      data: {
+        userId: session.user.id,
+        submissionId
+      }
+    })
+
+    return NextResponse.json({ 
+      success: true, 
+      savedPost: {
+        id: savedPost.id,
+        submissionId: savedPost.submissionId,
+        savedAt: savedPost.savedAt.toISOString()
+      }
+    }, { status: 201 })
+  } catch (error) {
+    console.error('Error saving post:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/app/saved-posts/page.tsx
+++ b/app/app/saved-posts/page.tsx
@@ -1,0 +1,279 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { motion } from 'framer-motion'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Bookmark, BookmarkX, PenTool } from 'lucide-react'
+import { DownloadPostButton } from '@/components/community/download-post-button'
+import Link from 'next/link'
+
+interface SavedPost {
+  id: string
+  savedPostId: string
+  title: string
+  content: string
+  createdAt: string
+  savedAt: string
+  user: {
+    firstName?: string
+    lastName?: string
+    name?: string
+  }
+  exercise?: {
+    title: string
+    topic: {
+      title: string
+      slug: string
+    }
+  }
+}
+
+export default function SavedPostsPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [posts, setPosts] = useState<SavedPost[]>([])
+  const [loading, setLoading] = useState(true)
+  const [unsavingPostId, setUnsavingPostId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/auth/signin')
+    }
+  }, [status, router])
+
+  useEffect(() => {
+    if (session?.user?.id) {
+      fetchSavedPosts()
+    }
+  }, [session])
+
+  const fetchSavedPosts = async () => {
+    try {
+      const response = await fetch('/api/saved-posts')
+      if (response.ok) {
+        const data = await response.json()
+        setPosts(data.posts || [])
+      }
+    } catch (error) {
+      console.error('Error fetching saved posts:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const unsavePost = async (savedPostId: string) => {
+    if (unsavingPostId) return
+    
+    setUnsavingPostId(savedPostId)
+    
+    try {
+      const response = await fetch(`/api/saved-posts/${savedPostId}`, {
+        method: 'DELETE'
+      })
+      
+      if (response.ok) {
+        setPosts(prev => prev.filter(p => p.savedPostId !== savedPostId))
+      }
+    } catch (error) {
+      console.error('Error unsaving post:', error)
+    } finally {
+      setUnsavingPostId(null)
+    }
+  }
+
+  const getExcerpt = (content: string, maxLength: number = 200) => {
+    if (content.length <= maxLength) return content
+    return content.substring(0, maxLength) + '...'
+  }
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    })
+  }
+
+  if (status === 'loading' || loading) {
+    return (
+      <section className="py-12 px-4 paper-texture min-h-screen">
+        <div className="max-w-content mx-auto text-center">
+          <div className="animate-pulse">
+            <div className="h-8 bg-sepia rounded w-1/2 mx-auto mb-4"></div>
+            <div className="h-4 bg-sepia rounded w-1/3 mx-auto"></div>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  if (status === 'unauthenticated') {
+    return null // Will redirect
+  }
+
+  return (
+    <section className="py-12 px-4 paper-texture min-h-screen">
+      <div className="max-w-content mx-auto">
+        {/* Header */}
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          className="text-center mb-12"
+        >
+          <div className="flex items-center justify-center gap-3 mb-6">
+            <Bookmark className="w-10 h-10 text-rust" />
+            <h1 className="text-4xl md:text-5xl font-typewriter font-bold text-ink">
+              Saved Posts
+            </h1>
+          </div>
+          <p className="text-xl font-serif text-forest max-w-3xl mx-auto leading-relaxed">
+            Your personal collection of inspiring writing from the community.
+            Return to these pieces whenever you need motivation or reference.
+          </p>
+        </motion.div>
+
+        {/* Saved Posts Count */}
+        {posts.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+            className="mb-8 text-center"
+          >
+            <Badge className="bg-rust/20 text-rust font-typewriter text-lg px-4 py-2">
+              {posts.length} saved {posts.length === 1 ? 'post' : 'posts'}
+            </Badge>
+          </motion.div>
+        )}
+
+        {/* Empty State */}
+        {posts.length === 0 ? (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.3 }}
+            className="text-center py-16"
+          >
+            <PenTool className="w-16 h-16 text-forest mx-auto mb-4" />
+            <h3 className="text-2xl font-typewriter font-bold text-ink mb-4">
+              No saved posts yet
+            </h3>
+            <p className="font-serif text-forest mb-6 max-w-md mx-auto">
+              Browse the community and save posts that inspire you. 
+              They'll appear here for easy access later.
+            </p>
+            <Link href="/community">
+              <Button className="btn-vintage">
+                Explore Community
+              </Button>
+            </Link>
+          </motion.div>
+        ) : (
+          <div className="space-y-6">
+            {posts.map((post, index) => (
+              <motion.div
+                key={post.savedPostId}
+                initial={{ opacity: 0, y: 30 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: index * 0.1 }}
+              >
+                <Card className="card-vintage border-2 hover:shadow-xl transition-all duration-300">
+                  <CardHeader>
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <CardTitle className="font-typewriter text-ink text-xl mb-2">
+                          {post.title || 'Exercise Response'}
+                        </CardTitle>
+                        <div className="flex items-center gap-3 mb-3 flex-wrap">
+                          <Badge className="bg-rust/20 text-rust font-typewriter">
+                            {post.user?.firstName && post.user?.lastName 
+                              ? `${post.user.firstName} ${post.user.lastName}`
+                              : post.user?.name || 'Anonymous Writer'
+                            }
+                          </Badge>
+                          {post.exercise && (
+                            <Badge className="bg-gold/20 text-ink font-typewriter">
+                              {post.exercise.topic.title}
+                            </Badge>
+                          )}
+                          <span className="text-sm font-serif text-forest">
+                            {formatDate(post.createdAt)}
+                          </span>
+                        </div>
+                        {post.exercise && (
+                          <p className="text-sm font-serif text-forest mb-2">
+                            From exercise: <span className="font-semibold">{post.exercise.title}</span>
+                          </p>
+                        )}
+                        <p className="text-xs font-serif text-forest/70">
+                          Saved on {formatDate(post.savedAt)}
+                        </p>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="font-serif text-forest leading-relaxed mb-4">
+                      {getExcerpt(post.content)}
+                    </p>
+                    
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-4">
+                        <Button 
+                          variant="ghost" 
+                          size="sm" 
+                          className="text-rust hover:text-rust/80"
+                          onClick={() => unsavePost(post.savedPostId)}
+                          disabled={unsavingPostId === post.savedPostId}
+                        >
+                          <BookmarkX className="w-4 h-4 mr-1" />
+                          Remove
+                        </Button>
+                        <DownloadPostButton post={post} />
+                      </div>
+                      
+                      {post.exercise && (
+                        <Link href={`/topics/${post.exercise.topic.slug}`}>
+                          <Button variant="outline" size="sm" className="btn-vintage text-xs">
+                            Try This Exercise
+                          </Button>
+                        </Link>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              </motion.div>
+            ))}
+          </div>
+        )}
+
+        {/* Call to Action */}
+        {posts.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, delay: 0.6 }}
+            className="text-center mt-16 p-8 bg-sepia/50 rounded-sm border-2 border-ink"
+          >
+            <h3 className="text-2xl font-typewriter font-bold text-ink mb-4">
+              Discover More Inspiration
+            </h3>
+            <p className="font-serif text-forest mb-6 max-w-2xl mx-auto">
+              The community is full of talented writers sharing their work. 
+              Continue exploring to find more pieces worth saving!
+            </p>
+            <Link href="/community">
+              <Button className="btn-vintage">
+                Browse Community
+              </Button>
+            </Link>
+          </motion.div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -4,7 +4,7 @@
 import { useSession, signOut } from 'next-auth/react'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
-import { PenTool, BookOpen, Users, Map, User, LogOut, Sparkles } from 'lucide-react'
+import { PenTool, BookOpen, Users, Map, User, LogOut, Sparkles, Bookmark } from 'lucide-react'
 import { motion } from 'framer-motion'
 
 export function Navigation() {
@@ -54,6 +54,10 @@ export function Navigation() {
                   <Link href="/ai-review" className="flex items-center space-x-2 text-ink hover:text-rust transition-colors font-typewriter">
                     <Sparkles className="w-4 h-4" />
                     <span>AI Review</span>
+                  </Link>
+                  <Link href="/saved-posts" className="flex items-center space-x-2 text-ink hover:text-rust transition-colors font-typewriter">
+                    <Bookmark className="w-4 h-4" />
+                    <span>Saved</span>
                   </Link>
                 </div>
 

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -50,6 +50,7 @@ model User {
   submissions   ExerciseSubmission[]
   communityPosts CommunityPost[]
   progress      UserProgress[]
+  savedPosts    SavedPost[]
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 }
@@ -95,10 +96,22 @@ model ExerciseSubmission {
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   exercise   Exercise @relation(fields: [exerciseId], references: [id], onDelete: Cascade)
   isPublic   Boolean  @default(false)
+  savedBy    SavedPost[]
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 
   @@unique([userId, exerciseId])
+}
+
+model SavedPost {
+  id           String             @id @default(cuid())
+  userId       String
+  submissionId String
+  user         User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  submission   ExerciseSubmission @relation(fields: [submissionId], references: [id], onDelete: Cascade)
+  savedAt      DateTime           @default(now())
+
+  @@unique([userId, submissionId])
 }
 
 model CommunityPost {


### PR DESCRIPTION
## Summary
This PR implements a complete save posts feature that allows users to bookmark community posts for later reading.

## Changes Included

### Database Schema
- **SavedPost model** in Prisma schema with relationships to `User` and `ExerciseSubmission`
- Unique constraint on `[userId, submissionId]` to prevent duplicate saves

### API Endpoints
- `GET /api/saved-posts` - Fetch all saved posts for authenticated user
- `POST /api/saved-posts` - Save a new post
- `DELETE /api/saved-posts/[id]` - Unsave a post

### UI Components
- **Save button** on community posts with toggle functionality
- **Saved Posts page** (`/saved-posts`) to view all bookmarked posts
- **Navigation update** - Added "Saved Posts" link to navigation menu

### Files Modified/Added
- `app/prisma/schema.prisma` - SavedPost model
- `app/app/api/saved-posts/route.ts` - Main API endpoints
- `app/app/api/saved-posts/[id]/route.ts` - Delete endpoint
- `app/app/api/community/posts/route.ts` - Updated to include save status
- `app/app/saved-posts/page.tsx` - Saved posts page
- `app/components/community/community-overview.tsx` - Save button UI
- `app/components/navigation.tsx` - Navigation link

## Testing
- Save/unsave posts via bookmark icon
- View saved posts at `/saved-posts`
- Verify save status persists across page reloads